### PR TITLE
Bump to traefik 2.10.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
           cd tests/
           docker-compose up -d
 
-          sleep 2
+          sleep 5
           docker ps
 
           curl -svo /dev/null 0:5555/foo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   # https://doc.traefik.io/traefik/getting-started/install-traefik/
   traefik:
     # https://hub.docker.com/_/traefik/tags
-    image: traefik:v2.9.4
+    image: traefik:v2.10.1
     container_name: traefik
     hostname: traefik
     restart: always


### PR DESCRIPTION
https://github.com/traefik/traefik/releases/tag/v2.10.1 // https://hub.docker.com/_/traefik/tags