### PR TITLE
Traefik: do not mount Docker socket to the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
 
     volumes:
       - "./traefik.yml:/etc/traefik/traefik.yml:ro"
-      - /var/run/docker.sock:/var/run/docker.sock:ro  # for containers discovery
       - "./letsencrypt:/var/log/letsencrypt/"  # certificates storage
 
     # https://doc.traefik.io/traefik/reference/static-configuration/env/


### PR DESCRIPTION
The Docker discovery should happen via the "socket-proxy" container that limits the access to the Docker API.