### PR TITLE
 Add the x-served-by HTTP middleware

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HOSTNAME: "foo.bar.local"
     steps:
       - uses: actions/checkout@v3
 
@@ -20,7 +22,7 @@ jobs:
           # make sure the letsencrypt directory is writable by the container
           sudo chown nobody:nogroup letsencrypt/
 
-          LOG_LEVEL=DEBUG \
+          LOG_LEVEL=DEBUG HOSTNAME=${HOSTNAME} \
             docker-compose up -d
 
           sleep 2
@@ -58,6 +60,9 @@ jobs:
           set -x
           curl --resolve nginx.foo.bar:80:127.0.0.1 nginx.foo.bar -sI | tee /dev/stderr | grep -i 'location: https://'
           curl --resolve nginx.foo.bar:443:127.0.0.1 https://nginx.foo.bar/ --insecure -sI | tee /dev/stderr | grep "200"
+
+          # request /whoami service
+          curl https://localhost/whoami -H "Host: ${HOSTNAME}" --insecure -v 2>&1 | grep x-served-by
 
           # Prometheus metrics are collected for this service
           curl 127.0.0.1:58888/metrics -s | grep 'nginx@docker' | grep service_request

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     # https://hub.docker.com/_/traefik/tags
     image: traefik:v3.0.0
     container_name: traefik
-    hostname: traefik
     restart: always
     user: nobody
     mem_limit: 128M
@@ -41,11 +40,13 @@ services:
 
     volumes:
       - "./traefik.yml:/etc/traefik/traefik.yml:ro"
+      - "./traefik_dynamic_conf.yml:/etc/traefik/traefik_dynamic_conf.yml:ro"
       - "./letsencrypt:/var/log/letsencrypt/"  # certificates storage
 
     # https://doc.traefik.io/traefik/reference/static-configuration/env/
     environment:
       TRAEFIK_CERTIFICATESRESOLVERS_MYRESOLVER_ACME_EMAIL: ${ACME_EMAIL:-foo@acme.net}
+      HOSTNAME: ${HOSTNAME:-traefik}
       # TRAEFIK_LOG_LEVEL: ${LOG_LEVEL:-INFO}
 
     # expose prom metrics at /traefik/metrics
@@ -57,11 +58,8 @@ services:
       # https://doc.traefik.io/traefik/routing/routers/#path-pathprefix-and-pathregexp
       traefik.http.routers.traefik-metrics.rule: "Host(`${HOSTNAME:-foo.bar}`) && Path(`/traefik/metrics`)"
       # https://doc.traefik.io/traefik/middlewares/http/replacepath/
-      traefik.http.routers.traefik-metrics.middlewares: "traefik-metrics,served-by"
+      traefik.http.routers.traefik-metrics.middlewares: "traefik-metrics"
       traefik.http.middlewares.traefik-metrics.replacepath.path: "/metrics"
-
-      # https://doc.traefik.io/traefik/middlewares/http/headers/
-      traefik.http.middlewares.served-by.headers.customresponseheaders.X-Served-By: ${HOSTNAME:-foo.bar}
 
     healthcheck:
       test: 'traefik healthcheck'
@@ -99,7 +97,6 @@ services:
       # https://doc.traefik.io/traefik/routing/routers/#path-pathprefix-and-pathregexp
       traefik.http.routers.whoami.rule: "Host(`${HOSTNAME:-foo.bar}`) && Path(`/whoami`)"
       # https://doc.traefik.io/traefik/middlewares/http/replacepath/
-      traefik.http.routers.whoami.middlewares: "whoami,served-by"
       traefik.http.middlewares.whoami.replacepath.path: "/"
 
 # https://docs.docker.com/compose/networking/#configure-the-default-network

--- a/traefik.yml
+++ b/traefik.yml
@@ -17,6 +17,11 @@ providers:
     watch: true  # Watch Docker events.
     allowEmptyServices: true  # Any servers load balancer defined for Docker containers is created regardless of the healthiness of the corresponding containers.
 
+  # https://doc.traefik.io/traefik/providers/file/
+  # allows us to define global middlewares for the web entryPoint
+  file:
+    filename: "/etc/traefik/traefik_dynamic_conf.yml"
+
 # https://doc.traefik.io/traefik/observability/metrics/prometheus/
 metrics:
   prometheus: {}
@@ -42,7 +47,11 @@ entryPoints:
     address: ":1443"
     http3:
       advertisedPort: 443
-
+    # https://doc.traefik.io/traefik/routing/entrypoints/#middlewares
+    # middlewares are defined in the traefik_dynamic_conf.yml file
+    http:
+      middlewares:
+        - "x-served-by@file"
 
 # https://doc.traefik.io/traefik/https/acme/
 certificatesResolvers:

--- a/traefik_dynamic_conf.yml
+++ b/traefik_dynamic_conf.yml
@@ -1,0 +1,8 @@
+http:
+  middlewares:
+    x-served-by:
+      # https://doc.traefik.io/traefik/middlewares/http/headers/
+      # https://doc.traefik.io/traefik/v2.1/providers/file/#go-templating
+      headers:
+        customResponseHeaders:
+          x-served-by: {{ env "HOSTNAME" }}


### PR DESCRIPTION
```
$ curl https://localhost/whoami -H 'Host: macbre.local' --insecure -v 2>&1 | grep x-served-by
< x-served-by: macbre.local
```

<img width="484" alt="Screenshot 2024-06-19 at 12 39 41" src="https://github.com/macbre/docker-traefik/assets/1929317/159032fd-734c-4dd0-bae1-05fd6e6f56c5">
